### PR TITLE
fix: Add curl to Dockerfile system dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ENV HF_HUB_ENABLE_HF_TRANSFER=1
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
     libgl1-mesa-glx \
+    curl \
     # other system dependencies from cog.yaml if any were missed (libgl1 is listed)
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The previous Dockerfile was missing `curl`, which is required for downloading the `pget` tool during the image build process. This resulted in a "curl: not found" error.

This commit adds `curl` to the `apt-get install` command in the Dockerfile to ensure it is available.